### PR TITLE
Restrict usage of same struct as IN/OUT for handler versions

### DIFF
--- a/handlers_manager_test.go
+++ b/handlers_manager_test.go
@@ -1,17 +1,19 @@
 package gorpc
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"reflect"
 	"testing"
 
-	"github.com/stretchr/testify/suite"
-	"context"
-
 	test_handler1 "github.com/sergei-svistunov/gorpc/test/handler1"
+	test_handler_common_type_in_different_versions_args "github.com/sergei-svistunov/gorpc/test/handler_common_type_in_different_versions_arguments"
+	test_handler_common_type_in_different_versions "github.com/sergei-svistunov/gorpc/test/handler_common_type_in_different_versions_return_values"
 	test_handler_foreign_arguments "github.com/sergei-svistunov/gorpc/test/handler_foreign_arguments"
 	test_handler_foreign_return_values "github.com/sergei-svistunov/gorpc/test/handler_foreign_return_values"
+
+	"github.com/stretchr/testify/suite"
 )
 
 // Suite definition
@@ -35,6 +37,12 @@ func (s *HandlersManagerSuite) SetupTest() {
 	err = s.hm.RegisterHandler(test_handler_foreign_return_values.NewHandler())
 	s.Error(err)
 	s.Equal(err.Error(), fmt.Sprintf(`Handler '%s' version '%s' return value: Structure must be fully defined in the same package. Type 'return_values.V1Res' is not.`, `/test/handler_foreign_return_values`, `V1`))
+
+	err = s.hm.RegisterHandler(test_handler_common_type_in_different_versions.NewHandler())
+	s.Error(err)
+
+	err = s.hm.RegisterHandler(test_handler_common_type_in_different_versions_args.NewHandler())
+	s.Error(err)
 }
 
 func TestRunSuite(t *testing.T) {

--- a/test/handler_common_type_in_different_versions_arguments/common_struct1.go
+++ b/test/handler_common_type_in_different_versions_arguments/common_struct1.go
@@ -1,0 +1,12 @@
+package handler_common_type_in_different_versions_arguments
+
+type CommonStruct1 struct {
+	F1 []CommonSubStruct `key:"f1" description:"f1"`
+	F2 bool              `key:"f2" description:"f2"`
+	F3 map[string]string `key:"f3" description:"f4"`
+	F4 []CommonStruct1   `key:"f4" description:"Recurcive type"`
+}
+
+type CommonSubStruct struct {
+	SubF1 []string `key:"sub_f1" description:"sub f1"`
+}

--- a/test/handler_common_type_in_different_versions_arguments/test_handler_common_type_in_different_versions.go
+++ b/test/handler_common_type_in_different_versions_arguments/test_handler_common_type_in_different_versions.go
@@ -1,0 +1,16 @@
+package handler_common_type_in_different_versions_arguments
+
+type Handler struct {
+}
+
+func NewHandler() *Handler {
+	return &Handler{}
+}
+
+func (h *Handler) Caption() string {
+	return "Test handler 1"
+}
+
+func (h *Handler) Description() string {
+	return "Handler for tests"
+}

--- a/test/handler_common_type_in_different_versions_arguments/v1.go
+++ b/test/handler_common_type_in_different_versions_arguments/v1.go
@@ -1,0 +1,21 @@
+package handler_common_type_in_different_versions_arguments
+
+import (
+	"context"
+)
+
+type v1Args struct {
+	Field CommonStruct1 `key:"common_type" description:"Field with shared type between handlers"`
+}
+
+type V1Res struct {
+	String string `json:"string" description:"String field"`
+	Int    int    `json:"int" description:"Int field"`
+}
+
+func (*Handler) V1(ctx context.Context, opts *v1Args) (*V1Res, error) {
+	return &V1Res{
+		String: "Test",
+		Int:    1,
+	}, nil
+}

--- a/test/handler_common_type_in_different_versions_arguments/v2.go
+++ b/test/handler_common_type_in_different_versions_arguments/v2.go
@@ -1,0 +1,21 @@
+package handler_common_type_in_different_versions_arguments
+
+import (
+	"context"
+)
+
+type v2Args struct {
+	Field CommonSubStruct `key:"common_type" description:"Field with shared type between handlers"`
+}
+
+type V2Res struct {
+	String string `json:"string" description:"String field"`
+	Int    int    `json:"int" description:"Int field"`
+}
+
+func (*Handler) V2(ctx context.Context, opts *v2Args) (*V2Res, error) {
+	return &V2Res{
+		String: "Test",
+		Int:    1,
+	}, nil
+}

--- a/test/handler_common_type_in_different_versions_arguments/v3.go
+++ b/test/handler_common_type_in_different_versions_arguments/v3.go
@@ -1,0 +1,17 @@
+package handler_common_type_in_different_versions_arguments
+
+import (
+	"context"
+)
+
+type V3Res struct {
+	String string `json:"string" description:"String field"`
+	Int    int    `json:"int" description:"Int field"`
+}
+
+func (*Handler) V3(ctx context.Context, opts *CommonSubStruct) (*V3Res, error) {
+	return &V3Res{
+		String: "Test",
+		Int:    1,
+	}, nil
+}

--- a/test/handler_common_type_in_different_versions_arguments/v4.go
+++ b/test/handler_common_type_in_different_versions_arguments/v4.go
@@ -1,0 +1,17 @@
+package handler_common_type_in_different_versions_arguments
+
+import (
+	"context"
+)
+
+type V4Res struct {
+	String string `json:"string" description:"String field"`
+	Int    int    `json:"int" description:"Int field"`
+}
+
+func (*Handler) V4(ctx context.Context, opts *CommonSubStruct) (*V4Res, error) {
+	return &V4Res{
+		String: "Test",
+		Int:    1,
+	}, nil
+}

--- a/test/handler_common_type_in_different_versions_arguments/v5.go
+++ b/test/handler_common_type_in_different_versions_arguments/v5.go
@@ -1,0 +1,17 @@
+package handler_common_type_in_different_versions_arguments
+
+import (
+	"context"
+)
+
+type V5Res struct {
+	String string `json:"string" description:"String field"`
+	Int    int    `json:"int" description:"Int field"`
+}
+
+func (*Handler) V5(ctx context.Context, opts *CommonStruct1) (*V5Res, error) {
+	return &V5Res{
+		String: "Test",
+		Int:    1,
+	}, nil
+}

--- a/test/handler_common_type_in_different_versions_return_values/common_struct1.go
+++ b/test/handler_common_type_in_different_versions_return_values/common_struct1.go
@@ -1,0 +1,13 @@
+package handler_common_type_in_different_versions_return_values
+
+type CommonStruct1 struct {
+	F1 []CommonSubStruct `key:"f1" description:"f1"`
+	F2 bool              `key:"f2" description:"f2"`
+	F3 interface{}       `key:"f3" description:"f3"`
+	F4 map[string]string `key:"f4" description:"f4"`
+	F5 []CommonStruct1   `key:"f5" description:"Recurcive type"`
+}
+
+type CommonSubStruct struct {
+	SubF1 []string `key:"sub_f1" description:"sub f1"`
+}

--- a/test/handler_common_type_in_different_versions_return_values/test_handler_common_type_in_different_versions.go
+++ b/test/handler_common_type_in_different_versions_return_values/test_handler_common_type_in_different_versions.go
@@ -1,0 +1,16 @@
+package handler_common_type_in_different_versions_return_values
+
+type Handler struct {
+}
+
+func NewHandler() *Handler {
+	return &Handler{}
+}
+
+func (h *Handler) Caption() string {
+	return "Test handler 1"
+}
+
+func (h *Handler) Description() string {
+	return "Handler for tests"
+}

--- a/test/handler_common_type_in_different_versions_return_values/v1.go
+++ b/test/handler_common_type_in_different_versions_return_values/v1.go
@@ -1,0 +1,23 @@
+package handler_common_type_in_different_versions_return_values
+
+import (
+	"context"
+)
+
+type v1Args struct {
+	ReqInt int  `key:"req_int" description:"Required integer argument"`
+	Int    *int `key:"int" description:"Unrequired integer argument"`
+}
+
+type V1Res struct {
+	String     string           `json:"string" description:"String field"`
+	Int        int              `json:"int" description:"Int field"`
+	CommonType *CommonSubStruct `json:"common_sub_struct" description:"Common shared struct"`
+}
+
+func (*Handler) V1(ctx context.Context, opts *v1Args) (*V1Res, error) {
+	return &V1Res{
+		String: "Test",
+		Int:    opts.ReqInt,
+	}, nil
+}

--- a/test/handler_common_type_in_different_versions_return_values/v2.go
+++ b/test/handler_common_type_in_different_versions_return_values/v2.go
@@ -1,0 +1,48 @@
+package handler_common_type_in_different_versions_return_values
+
+import (
+	"errors"
+
+	"context"
+)
+
+type v2Args struct {
+	ReqInt        int  `key:"req_int" description:"Required integer argument"`
+	ReturnErrorID *int `key:"error_id" description:"Handler returns error by id if defined"`
+}
+
+type V2Res struct {
+	Int        int            `json:"int" description:"Intfield"`
+	CommonType *CommonStruct1 `json:"common_struct" description:"Common shared struct"`
+}
+
+type V2ErrorTypes struct {
+	ERROR_TYPE1 error `text:"Error 1 description"`
+	ERROR_TYPE2 error `text:"Error 2 description"`
+	ERROR_TYPE3 error `text:"Error 3 description"`
+}
+
+var v2Errors V2ErrorTypes
+
+func (*Handler) V2ErrorsVar() *V2ErrorTypes {
+	return &v2Errors
+}
+
+func (*Handler) V2(ctx context.Context, opts *v2Args) (*V2Res, error) {
+	if opts.ReturnErrorID == nil {
+		return &V2Res{
+			Int: opts.ReqInt,
+		}, nil
+	}
+
+	switch *opts.ReturnErrorID {
+	case 1:
+		return nil, v2Errors.ERROR_TYPE1
+	case 2:
+		return nil, v2Errors.ERROR_TYPE2
+	case 3:
+		return nil, v2Errors.ERROR_TYPE3
+	default:
+		return nil, errors.New("Unknown error")
+	}
+}

--- a/test/handler_common_type_in_different_versions_return_values/v3.go
+++ b/test/handler_common_type_in_different_versions_return_values/v3.go
@@ -1,0 +1,23 @@
+package handler_common_type_in_different_versions_return_values
+
+import (
+	"context"
+)
+
+type v3Args struct {
+	ReqInt int  `key:"req_int" description:"Required integer argument"`
+	Int    *int `key:"int" description:"Unrequired integer argument"`
+}
+
+type V3Res struct {
+	String     string         `json:"string" description:"String field"`
+	Int        int            `json:"int" description:"Int field"`
+	CommonType *CommonStruct1 `json:"common_struct" description:"Common shared struct"`
+}
+
+func (*Handler) V3(ctx context.Context, opts *v3Args) (*V3Res, error) {
+	return &V3Res{
+		String: "Test",
+		Int:    opts.ReqInt,
+	}, nil
+}

--- a/test/handler_common_type_in_different_versions_return_values/v4.go
+++ b/test/handler_common_type_in_different_versions_return_values/v4.go
@@ -1,0 +1,14 @@
+package handler_common_type_in_different_versions_return_values
+
+import (
+	"context"
+)
+
+type v4Args struct {
+	ReqInt int  `key:"req_int" description:"Required integer argument"`
+	Int    *int `key:"int" description:"Unrequired integer argument"`
+}
+
+func (*Handler) V4(ctx context.Context, opts *v4Args) (*CommonStruct1, error) {
+	return &CommonStruct1{}, nil
+}

--- a/test/handler_common_type_in_different_versions_return_values/v5.go
+++ b/test/handler_common_type_in_different_versions_return_values/v5.go
@@ -1,0 +1,14 @@
+package handler_common_type_in_different_versions_return_values
+
+import (
+	"context"
+)
+
+type v5Args struct {
+	ReqInt int  `key:"req_int" description:"Required integer argument"`
+	Int    *int `key:"int" description:"Unrequired integer argument"`
+}
+
+func (*Handler) V5(ctx context.Context, opts *v5Args) (*CommonStruct1, error) {
+	return &CommonStruct1{}, nil
+}


### PR DESCRIPTION
If you try to use the same custom struct (or its parts) for different handler versions as input (arguments) structure or as result (output) structure - it should return an error and not allow this.